### PR TITLE
Fix duplicate E metric if the metric was defined

### DIFF
--- a/code/enrich_nvd.py
+++ b/code/enrich_nvd.py
@@ -33,7 +33,7 @@ def enrich(df, epss_df):
         kev_cve_list.append(vuln.get('cveID'))
     kev_df = pd.DataFrame(kev_cve_list, columns=['cve'])
     kev_df['cisa_kev'] = True
-    
+
     #Load VulnCheck KEV
     vulncheck_kev = get_vulncheck_data()
     vulncheck_kev_df = pd.DataFrame(vulncheck_kev, columns=['cve'])
@@ -73,7 +73,7 @@ def enrich(df, epss_df):
 
     print('Mapping KEV Data')
     df = pd.merge(df, kev_df, on='cve', how='left')
-    
+
     print('Mapping VulnCheck KEV Data')
     df = pd.merge(df, vulncheck_kev_df, on='cve', how='left')
 
@@ -153,9 +153,10 @@ def update_temporal_score(df, epss_threshold):
     df.loc[condition_ep4 & (df['cvss_version'].astype(str) == '4.0'), 'exploit_maturity'] = 'E:P'
 
     # Update vector with exploit maturity
-    #Remove "E:X" from base vector if it exists
-    df['cvss-bt_vector'] = df.apply(lambda row: f"{row['base_vector']}/{row['exploit_maturity']}" if 'E:X' not in row['base_vector'] and row['base_vector'] != 'N/A' \
-                                                   else row['base_vector'].replace('/E:X', f"/{row['exploit_maturity']}") if row['base_vector'] != 'N/A' \
+    # Replace "E:" from base vector if it exists
+    exploit_maturity_re = re.compile(r'/E:(POC|[AHFPUX])')
+    df['cvss-bt_vector'] = df.apply(lambda row: f"{row['base_vector']}/{row['exploit_maturity']}" if '/E:' not in row['base_vector'] and row['base_vector'] != 'N/A' \
+                                                   else exploit_maturity_re.sub(f"/{row['exploit_maturity']}", row['base_vector']) if row['base_vector'] != 'N/A' \
                                                    else row['base_vector'], axis=1)
 
     # Apply CVSS computation


### PR DESCRIPTION
Some base vectors define the E metric and that would cause the code to append the new E metric. Previously only undefined metrics (E:X) would be replaced. Duplicate metrics are not allowed and trigger a failure in the CVSS parser which causes the severity/score to resolve to `UNKNOWN`.

CVEs with E metrics:
```
CVE-2024-8273
CVE-2025-0133
CVE-2025-4615
CVE-2025-4616
CVE-2025-4617
CVE-2025-4618
CVE-2025-4619
CVE-2025-8095
CVE-2025-10685
CVE-2025-12420
CVE-2025-12940
CVE-2025-12941
CVE-2025-12942
CVE-2025-12943
CVE-2025-12944
CVE-2025-12945
CVE-2025-12946
CVE-2025-13470
CVE-2025-14179
CVE-2025-14340
CVE-2025-14986
CVE-2025-15577
CVE-2025-20628
CVE-2025-46826
CVE-2025-55211
CVE-2025-59056
CVE-2025-61643
CVE-2025-62586
CVE-2026-0227
CVE-2026-0228
CVE-2026-0229
CVE-2026-0230
CVE-2026-0231
CVE-2026-0232
CVE-2026-0233
CVE-2026-0234
CVE-2026-0238
CVE-2026-0239
CVE-2026-0240
CVE-2026-0241
CVE-2026-0242
CVE-2026-0243
CVE-2026-0244
CVE-2026-0245
CVE-2026-0246
CVE-2026-0247
CVE-2026-0248
CVE-2026-0249
CVE-2026-0250
CVE-2026-0251
CVE-2026-0256
CVE-2026-0257
CVE-2026-0258
CVE-2026-0259
CVE-2026-0261
CVE-2026-0262
CVE-2026-0263
CVE-2026-0264
CVE-2026-0265
CVE-2026-0300
CVE-2026-0403
CVE-2026-0404
CVE-2026-0405
CVE-2026-0406
CVE-2026-0407
CVE-2026-0408
CVE-2026-0636
CVE-2026-1788
CVE-2026-2415
CVE-2026-2451
CVE-2026-2452
CVE-2026-2539
CVE-2026-3206
CVE-2026-4395
CVE-2026-4731
CVE-2026-4732
CVE-2026-4734
CVE-2026-4735
CVE-2026-4736
CVE-2026-4737
CVE-2026-4738
CVE-2026-4739
CVE-2026-4741
CVE-2026-4742
CVE-2026-4743
CVE-2026-4744
CVE-2026-4745
CVE-2026-4746
CVE-2026-5944
CVE-2026-6735
CVE-2026-7262
CVE-2026-24732
CVE-2026-25660
CVE-2026-29121
CVE-2026-34088
```