### PR TITLE
feat: add exploit_maturity_source column for auditable E-value provenance

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,18 @@ Sources:
 | Unproven (U) (v4.0/3.1/3.0/2.0) | No exploit code is available, or an exploit is theoretical. | CVE not present in any threat intelligence source above. |
 | Not Defined (X) (v4.0/3.1/3.0/2.0) | Assigning this value to the metric will not influence the score. It means the user does not have enough information to assign a score. | We drop this value since we have information to assign a score. |
 
+#### `exploit_maturity_source` column
+
+The published CSV includes an `exploit_maturity_source` column recording **which threat-intelligence source(s) actually drove** each CVE's assigned Exploit Maturity (`E`) value (e.g. `cisa_kev|epss`). It is a `|`-separated list, appended as a trailing column (existing column order is unchanged), and is empty only for `E:U` rows.
+
+Because the sources are listed in **assignment precedence** order, attribution reflects the value a source can actually drive — not merely that the source flagged the CVE:
+
+- **`E:H`** (v3.1/3.0/2.0) / **`E:A`** (v4.0): `cisa_kev`, `vulncheck_kev`, `epss` (≥ threshold); `metasploit` contributes to `E:A` on v4.0 only.
+- **`E:F`** (v3.1/3.0/2.0): `metasploit`, `nuclei`.
+- **`E:P`/`E:POC`**: `exploitdb`, `poc_github`; `nuclei` contributes to `E:P` on v4.0 only.
+
+So a CVE in both CISA KEV and Metasploit scored `E:H` on v3.1 is attributed to `cisa_kev` (and `vulncheck_kev`/`epss` if applicable) but **not** `metasploit`, since Metasploit does not drive `E:H` on v3.x.
+
 
 ## Features
 This repository continuously enriches and publishes CVSS Temporal Scores based on the following threat intelligence:

--- a/code/enrich_nvd.py
+++ b/code/enrich_nvd.py
@@ -130,6 +130,53 @@ def get_vulncheck_data():
     return data
 
 
+def _candidate_sources(exploit_maturity, cvss_version):
+    """
+    Return the threat-intelligence sources that are eligible to drive a given
+    Exploit Maturity (E) value, ordered for stable output.
+
+    This mirrors the conditions in update_temporal_score exactly so that the
+    provenance string only ever lists sources that actually contributed to the
+    assigned E value (e.g. Metasploit drives E:A on 4.0 but not E:H on 3.x).
+    """
+    is_v4 = str(cvss_version) == '4.0'
+    if exploit_maturity in ('E:H', 'E:A'):
+        # E:H (3.x/2.0) and E:A (4.0) share the same KEV/EPSS triggers;
+        # 4.0 additionally escalates to "Attacked" on Metasploit.
+        sources = ['cisa_kev', 'vulncheck_kev', 'epss']
+        if is_v4:
+            sources.append('metasploit')
+        return sources
+    if exploit_maturity == 'E:F':
+        return ['metasploit', 'nuclei']
+    if exploit_maturity in ('E:P', 'E:POC'):
+        # 4.0 folds Nuclei into Proof-of-Concept; 3.x/2.0 treat Nuclei as E:F.
+        sources = ['exploitdb', 'poc_github']
+        if is_v4:
+            sources.insert(0, 'nuclei')
+        return sources
+    return []  # E:U or any value with no driving source
+
+
+def get_exploit_maturity_source(row, epss_threshold):
+    """
+    Build a pipe-delimited provenance string listing the source columns that
+    triggered this row's assigned Exploit Maturity value (e.g. 'cisa_kev|metasploit').
+
+    EPSS contributes as 'epss' only when its score meets the threshold. E:U rows
+    have no driving source and yield an empty string.
+    """
+    candidates = _candidate_sources(row['exploit_maturity'], row['cvss_version'])
+    triggered = []
+    for source in candidates:
+        if source == 'epss':
+            if row['epss'] >= epss_threshold:
+                triggered.append('epss')
+        elif bool(row[source]):
+            triggered.append(source)
+    return '|'.join(triggered)
+
+
 def update_temporal_score(df, epss_threshold):
     """
     Update temporal score and severity based on exploit maturity
@@ -151,6 +198,10 @@ def update_temporal_score(df, epss_threshold):
     df.loc[condition_ep & (df['cvss_version'].astype(str) == '2.0'), 'exploit_maturity'] = 'E:POC'
     df.loc[condition_ep & (df['cvss_version'].astype(str) != '2.0') & (df['cvss_version'].astype(str) != '4.0'), 'exploit_maturity'] = 'E:P'
     df.loc[condition_ep4 & (df['cvss_version'].astype(str) == '4.0'), 'exploit_maturity'] = 'E:P'
+
+    # Record which source(s) drove the assigned exploit maturity (provenance)
+    df['exploit_maturity_source'] = df.apply(
+        lambda row: get_exploit_maturity_source(row, epss_threshold), axis=1)
 
     # Update vector with exploit maturity
     # Replace "E:" from base vector if it exists

--- a/code/process_nvd.py
+++ b/code/process_nvd.py
@@ -82,7 +82,8 @@ def enrich_df(nvd_df):
         'exploitdb',
         'metasploit',
         'nuclei',
-        'poc_github'
+        'poc_github',
+        'exploit_maturity_source'
     ]
     cvss_bt_df = cvss_bt_df[columns]
     cvss_bt_df = cvss_bt_df.sort_values(by=['published_date'])

--- a/code/test_exploit_maturity_source.py
+++ b/code/test_exploit_maturity_source.py
@@ -1,0 +1,93 @@
+"""
+Tests for the exploit_maturity_source provenance column.
+
+These cases exercise update_temporal_score() directly with small synthetic
+DataFrames (no network calls) and assert that the assigned exploit maturity AND
+its provenance string agree for every CVSS version branch.
+
+Runnable two ways (no new dependencies — uses only pandas, already required):
+    pytest code/test_exploit_maturity_source.py
+    python3 code/test_exploit_maturity_source.py
+"""
+import pandas as pd
+
+import enrich_nvd
+
+THRESHOLD = enrich_nvd.EPSS_THRESHOLD  # 0.36
+
+# Real base vectors per version so compute_cvss() does not error.
+V31 = 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H'
+V20 = 'AV:N/AC:L/Au:N/C:C/I:C/A:C'
+V40 = 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:N/SI:N/SA:N'
+
+SOURCE_COLS = ['cisa_kev', 'vulncheck_kev', 'exploitdb',
+               'metasploit', 'nuclei', 'poc_github']
+
+
+def _row(cve, version, base_vector, epss=0.0, **flags):
+    row = {
+        'cve': cve,
+        'cvss_version': version,
+        'base_vector': base_vector,
+        'epss': epss,
+    }
+    for col in SOURCE_COLS:
+        row[col] = flags.get(col, False)
+    return row
+
+
+# (description, row, expected_exploit_maturity, expected_source)
+CASES = [
+    ('3.1 KEV -> E:H', _row('CVE-A', '3.1', V31, cisa_kev=True), 'E:H', 'cisa_kev'),
+    # Metasploit is NOT an E:H driver on 3.x, so it must be excluded from provenance.
+    ('3.1 EPSS+MSF -> E:H (epss only)',
+     _row('CVE-B', '3.1', V31, epss=0.50, metasploit=True), 'E:H', 'epss'),
+    ('3.1 Metasploit -> E:F', _row('CVE-C', '3.1', V31, metasploit=True), 'E:F', 'metasploit'),
+    ('3.1 Nuclei -> E:F', _row('CVE-D', '3.1', V31, nuclei=True), 'E:F', 'nuclei'),
+    ('3.1 ExploitDB -> E:P', _row('CVE-E', '3.1', V31, exploitdb=True), 'E:P', 'exploitdb'),
+    ('2.0 PoC-in-GitHub -> E:POC', _row('CVE-F', '2.0', V20, poc_github=True), 'E:POC', 'poc_github'),
+    ('3.1 no source -> E:U', _row('CVE-G', '3.1', V31), 'E:U', ''),
+    # 4.0 escalates to Attacked on Metasploit; KEV + MSF both drive it.
+    ('4.0 KEV+MSF -> E:A', _row('CVE-H', '4.0', V40, cisa_kev=True, metasploit=True),
+     'E:A', 'cisa_kev|metasploit'),
+    ('4.0 Nuclei -> E:P', _row('CVE-I', '4.0', V40, nuclei=True), 'E:P', 'nuclei'),
+    ('4.0 ExploitDB -> E:P', _row('CVE-J', '4.0', V40, exploitdb=True), 'E:P', 'exploitdb'),
+    ('3.1 VulnCheck+EPSS -> E:H', _row('CVE-K', '3.1', V31, vulncheck_kev=True, epss=0.40),
+     'E:H', 'vulncheck_kev|epss'),
+]
+
+
+def _compute():
+    df = pd.DataFrame([c[1] for c in CASES])
+    return enrich_nvd.update_temporal_score(df, THRESHOLD)
+
+
+def test_exploit_maturity_source_column_present():
+    df = _compute()
+    assert 'exploit_maturity_source' in df.columns
+
+
+def test_exploit_maturity_and_provenance():
+    df = _compute()
+    for i, (desc, _row_data, exp_maturity, exp_source) in enumerate(CASES):
+        assert df.loc[i, 'exploit_maturity'] == exp_maturity, (
+            f'{desc}: expected maturity {exp_maturity}, got {df.loc[i, "exploit_maturity"]}')
+        assert df.loc[i, 'exploit_maturity_source'] == exp_source, (
+            f'{desc}: expected source "{exp_source}", '
+            f'got "{df.loc[i, "exploit_maturity_source"]}"')
+
+
+def test_provenance_empty_only_for_unproven():
+    df = _compute()
+    for i in range(len(CASES)):
+        is_unproven = df.loc[i, 'exploit_maturity'] == 'E:U'
+        is_empty = df.loc[i, 'exploit_maturity_source'] == ''
+        assert is_unproven == is_empty, (
+            f'Row {i}: empty provenance must coincide with E:U')
+
+
+if __name__ == '__main__':
+    test_exploit_maturity_source_column_present()
+    test_exploit_maturity_and_provenance()
+    test_provenance_empty_only_for_unproven()
+    print('All exploit_maturity_source tests passed.')


### PR DESCRIPTION
## Summary
Emit a new `exploit_maturity_source` column that records which threat-intelligence source(s) drove each CVE's assigned Exploit Maturity (`E`) value, turning an opaque `E:H` into an auditable `cisa_kev|epss`.

## Problem / motivation
Today the CSV publishes the resulting `E` value (`E:H`, `E:A`, `E:F`, `E:P`, `E:POC`, `E:U`) but not *why* it was assigned. A consumer who sees `E:H` cannot tell whether it came from CISA KEV, VulnCheck KEV, EPSS crossing the 0.36 threshold, Metasploit, Nuclei, ExploitDB, or PoC-in-GitHub.

That ambiguity matters for prioritization. The seven source booleans already exist in the output, but the precedence rules in `update_temporal_score()` mean a true boolean does not necessarily explain the assigned `E` value — for example on CVSS 3.x a CVE that is in both CISA KEV and Metasploit lands at `E:H`, driven by KEV; Metasploit never enters the `E:H` decision. Consumers cannot reconstruct that from the raw booleans without re-implementing the scoring logic. The result is teams either over-trust a single source or hand-roll the precedence rules to recover provenance.

## Change
- `code/enrich_nvd.py`
  - Add `get_exploit_maturity_source(row, epss_threshold)` and a small helper `_candidate_sources(exploit_maturity, cvss_version)`. The helper mirrors the existing `condition_*` rules exactly, so provenance is derived from the same logic that assigns the `E` value rather than a parallel guess.
  - Populate `df['exploit_maturity_source']` immediately after the maturity assignments in `update_temporal_score()`. EPSS is reported as `epss` only when it meets the threshold; `E:U` rows yield an empty string.
- `code/process_nvd.py`
  - Append `exploit_maturity_source` to the output `columns` list. Existing column order is unchanged — the new field is added at the end, so current consumers are not disrupted.
- `README.md`
  - Document the new column under a short "Exploit Maturity Provenance" subsection.
- `code/test_exploit_maturity_source.py`
  - Add focused tests (no network) covering every `E` tier across CVSS 2.0/3.x/4.0, including the version-specific cases where Metasploit drives `E:A` on 4.0 but not `E:H` on 3.x, and where Nuclei is `E:F` on 3.x but folds into `E:P` on 4.0.

No new dependencies, no change to existing scores or vectors — the column is purely additive transparency.

## Security rationale
Exploit Maturity is the temporal signal most security teams lean on to prioritize remediation, and the sources behind it carry very different operational weight. A CVE in CISA KEV is a known-exploited, federally-mandated fix (BOD 22-01) with a real ATT&CK-observed campaign behind it; a CVE that only crosses the EPSS 0.36 threshold is a probabilistic forecast, not evidence of exploitation. Both currently surface as `E:H`. Exposing provenance lets a vulnerability-management program apply source-aware SLAs (e.g. KEV-driven findings on a tighter clock than EPSS-only forecasts) and produce defensible audit evidence for *why* an item was escalated — without weakening or changing the published CVSS-BT score itself.

## Testing / validation
Ran locally against a fresh clone with the project's pinned dependencies (`cvss`, `pandas`, `requests`, `ijson`):

- `python3 code/test_exploit_maturity_source.py` — standalone runner, all assertions pass (`All exploit_maturity_source tests passed.`).
- `python3 -m pytest code/test_exploit_maturity_source.py -q` — `3 passed`.
- `python3 -m py_compile code/enrich_nvd.py code/process_nvd.py code/test_exploit_maturity_source.py` — clean.

The tests assert both the assigned `exploit_maturity` and `exploit_maturity_source` for 11 synthetic CVEs spanning all `E` tiers and all three CVSS versions, and verify the invariant that an empty provenance string occurs only for `E:U`. Tests are offline by construction — `update_temporal_score()` does no I/O, so no live source feed is required to validate.
